### PR TITLE
pre should use margin instead of padding

### DIFF
--- a/markdown.css
+++ b/markdown.css
@@ -118,7 +118,7 @@
 }
 .markdown pre {
   margin-left: 34px;
-  padding-left: 4ch;
+  margin-left: 4ch;
 }
 .markdown blockquote {
   position: relative;

--- a/markdown.less
+++ b/markdown.less
@@ -116,7 +116,7 @@
 
     pre {
         margin-left: @four-space;
-        padding-left: @four-space-css3;
+        margin-left: @four-space-css3;
     }
     blockquote {
         position: relative;


### PR DESCRIPTION
Correcting a mistake that slipped in with the last commit where margin
and padding was mixed for pre elements.
