### PR TITLE
2 small bugs.

### DIFF
--- a/markdown.css
+++ b/markdown.css
@@ -18,7 +18,7 @@
   line-height: 20px;
   font-weight: normal;
   font-style: normal;
-  font-family: consolas, monaco, courier, "courier new", fixed-width;
+  font-family: consolas, monaco, courier, "courier new", monospace;
   color: #333333;
 }
 .markdown h1,

--- a/markdown.css
+++ b/markdown.css
@@ -118,7 +118,7 @@
 }
 .markdown pre {
   margin-left: 34px;
-  padding-left: 4ch;
+  margin-left: 4ch;
 }
 .markdown blockquote {
   position: relative;

--- a/markdown.less
+++ b/markdown.less
@@ -19,7 +19,7 @@
         line-height: @line-height;
         font-weight: normal;
         font-style: normal;
-        font-family: consolas,monaco,courier,"courier new",fixed-width;
+        font-family: consolas,monaco,courier,"courier new",monospace;
         color: @color;
     }
 

--- a/markdown.less
+++ b/markdown.less
@@ -116,7 +116,7 @@
 
     pre {
         margin-left: @four-space;
-        padding-left: @four-space-css3;
+        margin-left: @four-space-css3;
     }
     blockquote {
         position: relative;


### PR DESCRIPTION
This fixes 2 things. I wanted to make two separate pull requests but apparently I should have used two separate branches (?) to do that? Sorry, I am still a GitHub newbie.

This contains #6 where it fixes the CSS for `pre` which uses 2 different properties since 1ff71b7ba1, and also switches `fixed-width` to `monospace` in the `font-family`. That’s the only right generic font family according to [the spec](http://www.w3.org/TR/CSS2/fonts.html#monospace-def) (also [CSS3 spec](http://dev.w3.org/csswg/css3-fonts/#monospace-def)).
